### PR TITLE
Fix build failures on modern toolchains (fmt v9+, GCC 12+) and visualizer race condition

### DIFF
--- a/example/gmm_map_viz.cpp
+++ b/example/gmm_map_viz.cpp
@@ -1022,7 +1022,10 @@ protected:
                     update_pcd = gmm_map_viz->isEnvBBoxUpdated(prop_values_.atomicMapVizFlags);
                     gmm_map_viz->updateGeometry(prop_values_.atomicMapVizFlags, final_frame);
                     if (update_pcd){
-                        if (!gmm_map_viz->isMapCropped(prop_values_.atomicMapVizFlags)){
+			{
+              		std::lock_guard<std::mutex> locker(pcd_lock);
+
+              		if (!gmm_map_viz->isMapCropped(prop_values_.atomicMapVizFlags)){
                             env_bbox->min_bound_ = cur_env_min_bound.cast<double>();
                             env_bbox->max_bound_ = cur_env_max_bound.cast<double>();
                             surface_.pcd_cropped = t::geometry::PointCloud::FromLegacy(surface_.pcd);
@@ -1031,6 +1034,8 @@ protected:
                                                           env_bbox->min_bound_, env_bbox->max_bound_);
                             surface_.pcd_cropped = open3d::t::geometry::PointCloud::FromLegacy(*surface_.pcd.Crop(*env_bbox));
                         }
+			}
+
                     }
 
                     updateInfoAndFPS(info, fps, frame_idx, rgb_files.size(), T_eigen, gmm_map_viz,
@@ -1221,8 +1226,11 @@ protected:
 
                     if (!is_running_ || final_frame){
                         // Only copy if the pause button is detected!
-                        surface_.pcd = surface_.pcd_cropped.ToLegacy();
-                    }
+                        {
+			std::lock_guard<std::mutex> locker(pcd_lock);
+			surface_.pcd = surface_.pcd_cropped.ToLegacy();
+                    	}
+		}
                     is_scene_updated_ = true;
                 }
 
@@ -1372,8 +1380,11 @@ protected:
                         std::string pcd_file = dataset_param::result_path / "pointcloud.pcd";
                         std::cout << fmt::format("Saving pointcloud to file: {}\n", pcd_file);
                         open3d::io::WritePointCloudOption write_params;
+			{                        
+			std::lock_guard<std::mutex> locker(pcd_lock);
                         open3d::io::WritePointCloudToPCD(pcd_file, surface_.pcd, write_params);
-                        std::cout << "Completed saving pointcloud!\n\n";
+                        }
+			std::cout << "Completed saving pointcloud!\n\n";
                     }
 
                     if (prop_values_.save_occ_img){

--- a/include/path_planning/path_planner.h
+++ b/include/path_planning/path_planner.h
@@ -66,13 +66,13 @@ namespace gmm {
         inline std::string toStr() {
             std::stringstream result;
             result << fmt::format("{} Planner", planner_name) << std::endl;
-            result << fmt::format("Duration: {:.2f}ms", plan_duration) << std::endl;
-            result << fmt::format("{} Vertices, {} Edges", num_vertices, num_edges) << std::endl;
-            result << fmt::format("Memory: {:.2f}KB", memory_usage) << std::endl;
+            result << fmt::format("Duration: {:.2f}ms", plan_duration.load()) << std::endl;
+            result << fmt::format("{} Vertices, {} Edges", num_vertices.load(), num_edges.load()) << std::endl;
+            result << fmt::format("Memory: {:.2f}KB", memory_usage.load()) << std::endl;
             if (solution_cost == -1){
                 result << "No feasible solution!" << std::endl;
             } else {
-                result << fmt::format("Solution cost: {:.2f}m", solution_cost) << std::endl;
+                result << fmt::format("Solution cost: {:.2f}m", solution_cost.load()) << std::endl;
             }
             return result.str();
         }

--- a/libs/nigh/src/nigh/impl/non_atomic.hpp
+++ b/libs/nigh/src/nigh/impl/non_atomic.hpp
@@ -38,7 +38,7 @@
 #define NIGH_IMPL_NON_ATOMIC_HPP
 
 #include <atomic>
-
+#include <utility>
 namespace unc::robotics::nigh::impl {
     // Non-atomic class to mimic std::atomic, but ignore memory
     // ordering constraints.


### PR DESCRIPTION
## Summary
Three bugs found while setting up GMMap on Ubuntu with GCC 12.2 and fmt v12.
Bugs 1 and 2 block compilation entirely. Bug 3 fixes the root cause of the documented visualizer crash.

<img width="1222" height="267" alt="image" src="https://github.com/user-attachments/assets/644c4951-98aa-4898-8a9e-f2670ce6ff51" />

## Bug 1 — std::atomic passed to fmt::format without .load()
**File:** include/path_planning/path_planner.h, toStr()

fmt v9+ correctly rejects std::atomic<T> as a format argument since atomics aren't directly formattable. Older fmt silently allowed this.

Fix: call .load() on plan_duration, num_vertices, num_edges, memory_usage, and solution_cost before passing to fmt::format.

## Bug 2 — Missing #include <utility> in non_atomic.hpp
**File:** libs/nigh/src/nigh/impl/non_atomic.hpp

std::exchange is used on lines 170 and 174 but <utility> is never included.
Fails to compile on GCC 12+.

Fix: add #include <utility> to the include block.

## Bug 3 — pcd_lock declared but never acquired
**File:** example/gmm_map_viz.cpp

The README documents that the visualizer can crash because the construction thread outruns it, and works around it with the Update Interval and Visualization Latency sliders. 
The root cause is that pcd_lock (line 722) was declared to protect surface_.pcd shared between both threads, but std::lock_guard is never called on it anywhere.

Fix: wrap every read/write site of surface_.pcd with std::lock_guard<std::mutex> locker(pcd_lock):
- Line 1224: construction thread writes surface_.pcd
- Lines 1028-1032: visualizer reads surface_.pcd for cropping
- Line 1375: file save reads surface_.pcd

This eliminates the need for the latency slider workaround entirely.

## Evidence

<img width="314" height="322" alt="image" src="https://github.com/user-attachments/assets/fa1d1ac2-226d-4866-927b-88f65c4b8bd2" />
<img width="1218" height="313" alt="image" src="https://github.com/user-attachments/assets/6a9c0bf7-f878-426f-aa32-a8ab1c507f7a" />


## Test environment
- Ubuntu 22.04
- GCC 12.2.0
- fmt v12 (built from source)
- CMake 3.x